### PR TITLE
Allocation timeout flag

### DIFF
--- a/py/strato/racktest/infra/executioner.py
+++ b/py/strato/racktest/infra/executioner.py
@@ -31,7 +31,7 @@ class Executioner:
     def hosts(self):
         return self._hosts
 
-    def executeTestScenario(self):
+    def executeTestScenario(self, allocation_timeout):
         timeoutthread.TimeoutThread(self._testTimeout, self._testTimedOut)
         logging.info("Test timer armed. Timeout in %(seconds)d seconds", dict(seconds=self._testTimeout))
         discardinglogger.discardLogsOf(self.DISCARD_LOGGING_OF)
@@ -43,7 +43,9 @@ class Executioner:
         if not hasattr(self._test, 'hosts'):
             self._test.hosts = self.hosts
         logging.info("Allocating Nodes")
-        self._allocation = rackattackallocation.RackAttackAllocation(self._test.HOSTS)
+        self._allocation = rackattackallocation.RackAttackAllocation(
+            self._test.HOSTS,
+            timeout=allocation_timeout)
         logging.progress("Done allocating nodes")
         try:
             self._setUp()

--- a/py/strato/racktest/infra/rackattackallocation.py
+++ b/py/strato/racktest/infra/rackattackallocation.py
@@ -12,16 +12,14 @@ from strato.racktest.infra import logbeamfromlocalhost
 
 
 class RackAttackAllocation:
-    _TIMEOUT = 10 * 60
-
-    def __init__(self, hosts):
+    def __init__(self, hosts, timeout):
         self._hosts = hosts
         self._client = clientfactory.factory()
         self._allocation = self._client.allocate(
             requirements=self._rackattackRequirements(), allocationInfo=self._rackattackAllocationInfo())
 #       self._allocation.setForceReleaseCallback()
         try:
-            self._allocation.wait(timeout=self._TIMEOUT)
+            self._allocation.wait(timeout=timeout)
         except:
             logging.exception("Allocation failed, attempting post mortem")
             self._postMortemAllocation()

--- a/py/strato/racktest/runner/main.py
+++ b/py/strato/racktest/runner/main.py
@@ -36,6 +36,7 @@ parser.add_argument("--scenariosRoot", default="racktests")
 parser.add_argument("--configurationFile", default="/etc/racktest.conf")
 parser.add_argument("--parallel", type=int, default=0)
 parser.add_argument("--repeat", type=int, default=0)
+parser.add_argument("--allocationTimeout", type=int, default=10*60)
 args = parser.parse_args()
 if args.interactOnAssert:
     suite.enableInteractOnAssert()
@@ -64,7 +65,9 @@ class Runner:
     def runSequential(self):
         for scenario in self._scenarios:
             for instance in self._instances:
-                self._runScenario(scenario, instance)
+                self._runScenario(scenario,
+                                  instance,
+                                  self._args.allocationTimeout)
 
     def runParallel(self):
         os.environ['RACKTEST_MINIMUM_NICE_FOR_RACKATTACK'] = "1.0"
@@ -114,10 +117,11 @@ class Runner:
             with open(self._args.liveReportFilename, "w") as f:
                 json.dump(everything, f)
 
-    def _runScenario(self, scenario, instance):
+    def _runScenario(self, scenario, instance, allocation_timeout):
         before = time.time()
         popen = subprocess.Popen(
-            ['python', _single, args.configurationFile, scenario, instance], close_fds=True)
+            ['python', _single, args.configurationFile, scenario, instance,
+             str(allocation_timeout)], close_fds=True)
         self._pids.append(popen.pid)
         result = popen.wait()
         self._pids.remove(popen.pid)

--- a/py/strato/racktest/runner/single.py
+++ b/py/strato/racktest/runner/single.py
@@ -8,7 +8,7 @@ from strato.common import log
 import imp
 
 
-def runSingleScenario(scenarioFilename, instance):
+def runSingleScenario(scenarioFilename, instance, allocation_timeout):
     testName = os.path.splitext(scenarioFilename)[0].replace('/', '.')
     _configureTestLogging(testName + instance)
     logging.info("Running '%(scenarioFilename)s' as a test class (instance='%(instance)s')", dict(
@@ -16,7 +16,7 @@ def runSingleScenario(scenarioFilename, instance):
     try:
         module = imp.load_source('test', scenarioFilename)
         execute = executioner.Executioner(module.Test)
-        execute.executeTestScenario()
+        execute.executeTestScenario(allocation_timeout=allocation_timeout)
     except:
         logging.exception(
             "Failed running '%(scenarioFilename)s' as a test class (instance='%(instance)s')",
@@ -39,4 +39,6 @@ def _configureTestLogging(testName):
 if __name__ == "__main__":
     import sys
     config.load(sys.argv[1])
-    runSingleScenario(sys.argv[2], sys.argv[3])
+    runSingleScenario(sys.argv[2],
+                      sys.argv[3],
+                      allocation_timeout=int(sys.argv[4]))


### PR DESCRIPTION
Add a flag for specifying timeout period for waiting for allocations of nodes.
Usage example: make beztest REGEXP="--allocationTimeout=1"