### PR TITLE
Make Forked killable

### DIFF
--- a/example_racktests/2_seed.py
+++ b/example_racktests/2_seed.py
@@ -1,5 +1,6 @@
 from strato.racktest.infra.suite import *
 from example_seeds import addition
+import time
 
 
 class Test:
@@ -24,3 +25,27 @@ class Test:
         TS_ASSERT(forked.poll())
         TS_ASSERT_EQUALS(forked.result(), 5)
         TS_ASSERT('OUTPUT LINE' in forked.output())
+
+        forked = host.it.seed.forkCode(
+            "import time\nwhile True: time.sleep(2)", takeSitePackages=True)
+        TS_ASSERT(forked.poll() is None)
+        TS_ASSERT(forked.poll() is None)
+        forked.kill()
+        for i in xrange(10):
+            if forked.poll() is None:
+                time.sleep(1)
+            else:
+                break
+        TS_ASSERT_EQUALS(forked.poll(), False)
+
+        forked = host.it.seed.forkCode(
+            "import time\nwhile True: time.sleep(2)", takeSitePackages=True)
+        TS_ASSERT(forked.poll() is None)
+        TS_ASSERT(forked.poll() is None)
+        forked.kill('TERM')
+        for i in xrange(10):
+            if forked.poll() is None:
+                time.sleep(1)
+            else:
+                break
+        TS_ASSERT_EQUALS(forked.poll(), False)

--- a/py/strato/racktest/hostundertest/builtinplugins/seed.py
+++ b/py/strato/racktest/hostundertest/builtinplugins/seed.py
@@ -156,5 +156,10 @@ class _Forked:
     def output(self):
         return self._host.ssh.ftp.getContents("/tmp/output%s.txt" % self._unique)
 
+    def kill(self, signalName=None):
+        if signalName is None:
+            signalName = '9'
+        self._host.ssh.run.script("kill -%s %s" % (signalName, self._pid))
+
 
 plugins.register('seed', Seed)


### PR DESCRIPTION
This commit adds a kill method to the _Forked instances returned by
the seed racktest plugin. This allows spawning background processes
and killing them at the end of a test.