### PR TITLE
Trace exceptions thrown by callables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ racktest:
 virttest:
 	RACKATTACK_PROVIDER=tcp://localhost:1014@@amqp://guest:guest@localhost:1013/%2F@@http://localhost:1016 $(MAKE) racktest
 phystest:
-	RACKATTACK_PROVIDER=tcp://rackattack-provider:1014@@amqp://guest:guest@rackattack-provider:1013/%2F@@http://rackattack-provider:1016 $(MAKE) racktest
+	RACKATTACK_PROVIDER=tcp://rackattack-provider.dc1:1014@@amqp://guest:guest@rackattack-provider.dc1:1013/%2F@@http://rackattack-provider.dc1:1016 $(MAKE) racktest
 devphystest:
 	RACKATTACK_PROVIDER=tcp://rack01-server58:1014@@amqp://guest:guest@rack01-server58:1013/%2F@@http://rack01-server58:1016 $(MAKE) racktest
 

--- a/example_racktests/2_seed.py
+++ b/example_racktests/2_seed.py
@@ -1,5 +1,6 @@
 from strato.racktest.infra.suite import *
 from example_seeds import addition
+from example_seeds import customlogging
 import time
 
 SIGNALLED_CALLABLE_CODE = """
@@ -75,3 +76,16 @@ class Test:
             else:
                 break
         TS_ASSERT_EQUALS(forked.poll(), True)
+
+        logFilePath = "/tmp/2_seed_configureLogAndThrow"
+        messageToLookFor = "this message is expected to be traced in case callable throws"
+        forked = host.it.seed.forkCallable(customlogging.configureLogAndThrow, logFilePath, messageToLookFor)
+        for i in xrange(10):
+            if forked.poll() is None:
+                time.sleep(1)
+            else:
+                break
+        TS_ASSERT_EQUALS(forked.poll(), False)
+        time.sleep(1)
+        output = host.it.ssh.ftp.getContents(logFilePath).strip()
+        TS_ASSERT(messageToLookFor in output)

--- a/example_seeds/customlogging.py
+++ b/example_seeds/customlogging.py
@@ -1,0 +1,6 @@
+import logging
+
+
+def configureLogAndThrow(filePath, throwMessage):
+    logging.basicConfig(level=logging.INFO, filename=filePath)
+    raise Exception(throwMessage)


### PR DESCRIPTION
This commit refactors the seed plugin to trace exceptions thrown by
callables. It is the user's responsibility to configure logging properly.