### PR TITLE
Add option to not join pythonNamespaces

### DIFF
--- a/py/strato/racktest/hostundertest/builtinplugins/seed.py
+++ b/py/strato/racktest/hostundertest/builtinplugins/seed.py
@@ -15,7 +15,7 @@ class Seed:
         self._host = host
 
     def runCode(self, code, takeSitePackages=False, outputTimeout=None,
-                excludePackages=None, joinPythonNamespaces=False):
+                excludePackages=None, joinPythonNamespaces=True):
         """
         make sure to assign to 'result' in order for the result to come back!
         for example: "runCode('import yourmodule\nresult = yourmodule.func()\n')"
@@ -51,13 +51,13 @@ class Seed:
         result = self._downloadResult(unique)
         return result, output
 
-    def forkCode(self, code, takeSitePackages=False, excludePackages=None):
+    def forkCode(self, code, takeSitePackages=False, excludePackages=None, joinPythonNamespaces=True):
         """
         make sure to assign to 'result' in order for the result to come back!
         for example: "runCode('import yourmodule\nresult = yourmodule.func()\n')"
         """
         unique = self._unique()
-        self._install(code, unique, takeSitePackages, excludePackages)
+        self._install(code, unique, takeSitePackages, excludePackages, joinPythonNamespaces)
         return _Forked(self._host, unique)
 
     def forkCallable(self, callable, *args, **kwargs):


### PR DESCRIPTION
As many seeds don't require the upseto join namespaces, and running packegg without it is a lot faster, I'd like to add the option to not join namespaces for the egg building.
The seed running however, should take into account that the seed being packed can be in a different repo.