### PR TITLE
Changed place for running teardown . Reason - to get logs if setup fails

### DIFF
--- a/py/strato/racktest/infra/executioner.py
+++ b/py/strato/racktest/infra/executioner.py
@@ -55,7 +55,7 @@ class Executioner:
             try:
                 self._tearDown()
             except:
-                logging.ERROR("Tear down failure")
+                logging.exception("Tear down failure")
             wasAllocationFreedSinceAllHostsWereReleased = not bool(self._hosts)
             if not wasAllocationFreedSinceAllHostsWereReleased:
                 try:

--- a/py/strato/racktest/infra/executioner.py
+++ b/py/strato/racktest/infra/executioner.py
@@ -50,11 +50,12 @@ class Executioner:
         logging.progress("Done allocating nodes")
         try:
             self._setUp()
-            try:
-                self._run()
-            finally:
-                self._tearDown()
+            self._run()
         finally:
+            try:
+                self._tearDown()
+            except:
+                logging.ERROR("Tear down failure")
             wasAllocationFreedSinceAllHostsWereReleased = not bool(self._hosts)
             if not wasAllocationFreedSinceAllHostsWereReleased:
                 try:


### PR DESCRIPTION
Reason : 
Get logs if test_setup failed.
Change place calling teardown to finally , for teardown to work needed change in test to configure logs in init (pull request for donkey)

@eliran-stratoscale @rom-stratoscale @romang-stratoscale 